### PR TITLE
schema type updated with necessary typeDef changes

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,5 @@
 const { ApolloServer } = require('apollo-server-express');
 const { ApolloServerPluginDrainHttpServer } = require('apollo-server-core');
-//const { buildSubgraphSchema } = require('@apollo/subgraph');
 const { makeExecutableSchema } = require('@graphql-tools/schema');
 const express = require('express');
 const http = require('http');
@@ -12,7 +11,6 @@ const { resolvers } = require('./src/graphql/resolvers');
 const { transformSchemaWithDirectives, uppercaseDirectiveTypeDefs } = require('./src/graphql/directives');
 
 const knex = KNEX(knexConfig.development);
-//console.log(knex);
 // Bind all Models to the knex instance. Only need to do once
 Model.knex(knex);
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const { ApolloServer } = require('apollo-server-express');
 const { ApolloServerPluginDrainHttpServer } = require('apollo-server-core');
-const { buildSubgraphSchema } = require('@apollo/subgraph');
+//const { buildSubgraphSchema } = require('@apollo/subgraph');
+const { makeExecutableSchema } = require('@graphql-tools/schema');
 const express = require('express');
 const http = require('http');
 const KNEX = require('knex');
@@ -11,7 +12,7 @@ const { resolvers } = require('./src/graphql/resolvers');
 const { transformSchemaWithDirectives, uppercaseDirectiveTypeDefs } = require('./src/graphql/directives');
 
 const knex = KNEX(knexConfig.development);
-console.log(knex);
+//console.log(knex);
 // Bind all Models to the knex instance. Only need to do once
 Model.knex(knex);
 
@@ -19,7 +20,7 @@ async function startApolloServer(typeDefs, resolvers) {
   const app = express();
   const httpServer = http.createServer(app);
 
-  let createdSchema = buildSubgraphSchema({ 
+  let createdSchema = makeExecutableSchema({ 
     typeDefs: [
       uppercaseDirectiveTypeDefs,
       ...typeDefs

--- a/src/graphql/directives/uppercaseDirective.js
+++ b/src/graphql/directives/uppercaseDirective.js
@@ -28,12 +28,25 @@ const uppercaseDirective = new GraphQLDirective({
 
 const uppercaseDirectiveTypeDefs = `directive @${uppercaseDirective.name} on FIELD_DEFINITION | INPUT_FIELD_DEFINITION`;
 
+const defaultFieldResolver = async (
+  fieldConfig,
+  _fieldName,
+  typeName
+) => {
+  console.log(fieldConfig, _fieldName, typeName);
+  return {fieldConfig, _fieldName, typeName};
+};
+
 // This function takes in a schema and adds upper-casing logic to every resolver for an object field that has the 'upper' directive
 function upperDirectiveTransformer(schema) {
   return mapSchema(schema, {
     // Executes once for each object field in the schema
     // Add other MapperKinds, such as ENUM_VALUE, for other locations
-    [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+    [MapperKind.OBJECT_FIELD]: (
+      fieldConfig, 
+      _fieldName,
+      typeName
+      ) => {
       // Check whether this field has the specified directive
       const upperDirective = getDirective(schema, fieldConfig, uppercaseDirective.name)?.[0];
       if (upperDirective) {
@@ -41,26 +54,13 @@ function upperDirectiveTransformer(schema) {
         // Replace the original resolver/GQL with a function that calls the original resolver, then converts its result to upper case
         fieldConfig.resolve = async function (source, args, context, info) {
           const result = await resolve(source, args, context, info);
-          if (typeof result === 'string') {
+          console.log(`result: ${JSON.stringify(result)}`);
+          if (typeof result.typeName === 'string') {
             return result.toUpperCase();
           }
           return result;
         }
         return fieldConfig;
-      }
-    },
-    [MapperKind.INPUT_OBJECT_FIELD]: (inputConfig) => {
-      const upperDirective = getDirective(schema, inputConfig, uppercaseDirective.name)?.[0];
-      if (upperDirective) {
-        const { resolve = defaultFieldResolver } = inputConfig;
-        inputConfig.resolve = async function (source, args, context, info) {
-          const result = await resolve(source, args, context, info);
-          if (typeof result === 'string') {
-            return result.toUpperCase();
-          }
-          return result;
-        }
-        return inputConfig;
       }
     }
   });

--- a/src/graphql/type-defs/company-type-defs.js
+++ b/src/graphql/type-defs/company-type-defs.js
@@ -1,20 +1,20 @@
 const { gql } = require('apollo-server-express');
 
 const wrestlerTypeDefs = gql`
-    extend type Mutation {
+    type Mutation {
         createCompany(input: CreateCompanyInput!) : WrestlingCompany!
     }
 
     # @upper directive set to ensure that the input is uppercase
     input CreateCompanyInput {
-        name: String! @upper
+        name: String!
         allowedDivisions: [ChampionshipDivisions]!
         maxRosterSize: Int!
         headquarterCity: String
         yearStarted: Int
     }
 
-    extend type Query {
+    type Query {
         companies: [WrestlingCompany!]!
     }
 

--- a/src/graphql/type-defs/wrestler-type-defs.js
+++ b/src/graphql/type-defs/wrestler-type-defs.js
@@ -1,7 +1,7 @@
 const { gql } = require('apollo-server-express');
 
 const wrestlerTypeDefs = gql`
-    extend type Mutation {
+    type Mutation {
         createWrestler(input: CreateWrestlerInput!) : Wrestler!
     }
 
@@ -14,10 +14,10 @@ const wrestlerTypeDefs = gql`
     }
 
     input WrestlingCompanyInput {
-        companyName: String! @upper
+        companyName: String!
     }
 
-    extend type Query {
+    type Query {
         wrestlers: [Wrestler]
     }
 


### PR DESCRIPTION
Schema moved from `@apollo/subgraph` buildSubgraphSchema to `@graphql-tools/schema` makeExecutableSchema, due to subgraph not being needed. TypeDef updates due to these changes